### PR TITLE
Automatic Swagger API generation

### DIFF
--- a/balance/models.py
+++ b/balance/models.py
@@ -4,8 +4,8 @@ from company.models import Company
 
 
 class BankBalance(models.Model):
-    date = models.DateField()
-    money = models.PositiveIntegerField()
+    date = models.DateField(help_text='The date the balance was recorded on')
+    money = models.PositiveIntegerField(help_text='The amount of money available')
     company = models.ForeignKey(
         Company,
         on_delete=models.CASCADE,

--- a/balance/month_urls.py
+++ b/balance/month_urls.py
@@ -5,4 +5,5 @@ from . import views
 
 urlpatterns = [
     path('', views.MonthView.as_view(), name='month'),
+    path('byDateRange/', views.MonthByDateRangeView.as_view(), name='month-by-date-range'),
 ]

--- a/balance/serializers.py
+++ b/balance/serializers.py
@@ -26,6 +26,17 @@ class BalanceSerializer(serializers.Serializer):
     money = serializers.IntegerField()
 
 
+class MonthYearSerializer(serializers.Serializer):
+    year = serializers.IntegerField()
+    month = serializers.IntegerField()
+
+    def validate_month(self, month):
+        if not 1 <= month <= 12:
+            raise serializers.ValidationError('Month must be between 1 and 12')
+
+        return month
+
+
 class MonthSerializer(serializers.Serializer):
     year = serializers.IntegerField()
     month = serializers.IntegerField()

--- a/balance/serializers.py
+++ b/balance/serializers.py
@@ -21,14 +21,14 @@ class BankBalanceSerializer(LiquidatorSerializer):
 
 
 class BalanceSerializer(serializers.Serializer):
-    company_id = serializers.IntegerField()
-    date = serializers.DateField()
-    money = serializers.IntegerField()
+    company_id = serializers.IntegerField(help_text='The ID of the company')
+    date = serializers.DateField(help_text='The date the balance was calculated for')
+    money = serializers.IntegerField(help_text='The balance on the given date')
 
 
 class MonthYearSerializer(serializers.Serializer):
-    year = serializers.IntegerField()
-    month = serializers.IntegerField()
+    year = serializers.IntegerField(help_text='The year')
+    month = serializers.IntegerField(help_text='The month. Must be between 1 and 12')
 
     def validate_month(self, month):
         if not 1 <= month <= 12:
@@ -37,12 +37,16 @@ class MonthYearSerializer(serializers.Serializer):
         return month
 
 
-class MonthSerializer(serializers.Serializer):
-    year = serializers.IntegerField()
-    month = serializers.IntegerField()
-    start_balance = serializers.IntegerField()
-    lowest_balance = BalanceSerializer()
-    transactions = TransactionSerializer(many=True)
-    recurring = RecurringTransactionOccurenceSerializer(many=True)
-    balances = BalanceSerializer(many=True)
-    bank_balances = BankBalanceSerializer(many=True)
+class MonthSerializer(MonthYearSerializer):
+    start_balance = serializers.IntegerField(help_text='The incoming balance from the previous month')
+    lowest_balance = BalanceSerializer(help_text='The lowest balance in the month. This can be the `start_balance`')
+    transactions = TransactionSerializer(
+        many=True,
+        help_text='All transactions that occured in the month (includes recurring transactions that are changed)',
+    )
+    recurring = RecurringTransactionOccurenceSerializer(
+        many=True,
+        help_text='All recurring transactions that have occurences during the month',
+    )
+    balances = BalanceSerializer(many=True, help_text='The balances each day the balance changed')
+    bank_balances = BankBalanceSerializer(many=True, help_text='All bank balances from the month')

--- a/balance/views.py
+++ b/balance/views.py
@@ -15,18 +15,22 @@ class BankBalanceMixin(CompanyFilterMixin):
 
 
 class BankBalanceView(BankBalanceMixin, RetrieveCreateUpdateDestroyView):
+    """Manage a bank balance for a company."""
     pass
 
 
 class BankBalanceByDateView(BankBalanceMixin, RetrieveView):
+    """Get a bank balance for a company by date."""
     lookup_field = 'date'
 
 
 class BankBalanceByDateRangeView(BankBalanceMixin, ByDateRangeView):
+    """Get a bank balance for a company by date range."""
     pass
 
 
 class BalanceView(RetrieveView):
+    """Get a balance for a company by date."""
     serializer_class = BalanceSerializer
     request_serializer_class = DateSerializer
 
@@ -40,6 +44,7 @@ class BalanceView(RetrieveView):
 
 
 class BalanceByDateRangeView(ManyMixin, ByDateRangeMixin, RetrieveView):
+    """Get a balance for a company by date range."""
     serializer_class = BalanceSerializer
 
     def get_object(self):
@@ -49,6 +54,7 @@ class BalanceByDateRangeView(ManyMixin, ByDateRangeMixin, RetrieveView):
 
 
 class MonthView(RetrieveView):
+    """Get a month for a company by year and month number."""
     serializer_class = MonthSerializer
     request_serializer_class = MonthYearSerializer
 
@@ -67,6 +73,7 @@ class MonthView(RetrieveView):
 
 
 class MonthByDateRangeView(ManyMixin, ByDateRangeMixin, RetrieveView):
+    """Get a month for a company by date range."""
     serializer_class = MonthSerializer
 
     def get_object(self):

--- a/balance/views.py
+++ b/balance/views.py
@@ -2,9 +2,9 @@ from rest_framework.exceptions import ParseError
 
 from base.views import RetrieveCreateUpdateDestroyView, ByDateRangeView, RetrieveView
 from base.mixins import CompanyFilterMixin, ManyMixin, ByDateRangeMixin
-from base.serializers import DateSerializer, DateRangeSerializer
+from base.serializers import DateSerializer
 from .models import BankBalance
-from .serializers import BankBalanceSerializer, BalanceSerializer, MonthSerializer
+from .serializers import BankBalanceSerializer, BalanceSerializer, MonthSerializer, MonthYearSerializer
 from .utils import Balance, Month
 
 
@@ -28,9 +28,10 @@ class BankBalanceByDateRangeView(BankBalanceMixin, ByDateRangeView):
 
 class BalanceView(RetrieveView):
     serializer_class = BalanceSerializer
+    request_serializer_class = DateSerializer
 
     def get_object(self):
-        arg_serializer = DateSerializer(data=self.get_data())
+        arg_serializer = self.request_serializer_class(data=self.get_data())
         arg_serializer.is_valid(raise_exception=True)
 
         date = arg_serializer.validated_data['date']
@@ -49,12 +50,15 @@ class BalanceByDateRangeView(ManyMixin, ByDateRangeMixin, RetrieveView):
 
 class MonthView(RetrieveView):
     serializer_class = MonthSerializer
+    request_serializer_class = MonthYearSerializer
 
     def get_object(self):
         company_id = self.get_company_id()
-        data = self.get_data()
-        year = int(data['year'])
-        month = int(data['month'])
+        serializer = self.request_serializer_class(data=self.get_data())
+        serializer.is_valid(raise_exception=True)
+
+        year = serializer.data['year']
+        month = serializer.data['month']
 
         try:
             return Month.get(company_id, year, month)

--- a/base/api.py
+++ b/base/api.py
@@ -1,0 +1,64 @@
+from drf_yasg.inspectors import SwaggerAutoSchema
+from drf_yasg.openapi import Parameter, Response
+
+
+class LiquidatorAutoSchema(SwaggerAutoSchema):
+    def get_query_parameters(self):
+        parameters = super().get_query_parameters()
+
+        if self.method in ['GET', 'DELETE']:
+            company_id_field = self.view.company_id_field
+            if company_id_field:
+                for parameter in parameters:
+                    if parameter.name == company_id_field:
+                        break
+                else:
+                    parameters.append(
+                        Parameter(
+                            name=company_id_field,
+                            in_='query',
+                            type='integer',
+                            description='The ID of the company to manage',
+                            required=True,
+                        )
+                    )
+
+            if not getattr(self.view, 'request_serializer_class', None):
+                for field in ['lookup_query_field', 'lookup_arg_field', 'lookup_field']:
+                    lookup_field = getattr(self.view, field, None)
+                    if lookup_field:
+                        for parameter in parameters:
+                            if parameter.name == lookup_field:
+                                break
+                        else:
+                            parameters.append(
+                                Parameter(
+                                    name=lookup_field,
+                                    in_='query',
+                                    type='string',
+                                    required=True,
+                                )
+                            )
+                        break
+
+        return parameters
+
+    def get_query_serializer(self):
+        serializer = super().get_query_serializer()
+        serializer_class = getattr(self.view, 'request_serializer_class', None)
+
+        if not serializer and serializer_class:
+            serializer = serializer_class()
+
+        return serializer
+
+    def get_responses(self):
+        responses = super().get_responses()
+
+        if '401' not in responses:
+            responses['401'] = Response("Not authenticated")
+
+        if '403' not in responses:
+            responses['403'] = Response("You don't have access to do this operation on this company")
+
+        return responses

--- a/base/api.py
+++ b/base/api.py
@@ -1,49 +1,115 @@
 from drf_yasg.inspectors import SwaggerAutoSchema
-from drf_yasg.openapi import Parameter, Response
+from drf_yasg.openapi import Parameter
 
 
 class LiquidatorAutoSchema(SwaggerAutoSchema):
+    """
+    The default AutoSchema class for the Liquidator project.
+
+    An AutoSchema extracts info about views and generates a Swagger API.
+    This class adds parameters and responses that are used for most
+    Liquidator views.
+
+    If a view needs to add or modify Swagger attributes it should use
+    the decorator `drf_yasg.utils.swagger_auto_schema`. If this class
+    isn't needed at all, set `auto_schema=drf_yasg.inspectors.SwaggerAutoSchema`.
+
+    One feature of this class is the improved handling of query parameters. If the
+    `lookup_query_field`, `lookup_arg_field` or `lookup_field` is set it is added to
+    Swagger as a query parameter. If the `request_serializer_class` is set it overrides
+    the default query parameters.
+
+    The `company_id` field is added to all `GET` and `DELETE` endpoints, unless explicitly
+    defined on the view.
+
+    See [the drf-yasg docs](https://drf-yasg.readthedocs.io/en/stable/custom_spec.html)
+    for details.
+    """
+
+    def get_help_text(self, field_name):
+        """Helper function that returns the help text for a field, or None if there is no help text."""
+        try:
+            if self.view.serializer_class:
+                serializer = self.view.serializer_class()
+
+                if field_name in serializer.fields and serializer.fields[field_name].help_text:
+                    return serializer.fields[field_name].help_text
+
+        except AttributeError:
+            pass
+
+        return None
+
+    def get_company_id_parameter(self):
+        """
+        Helper function that creates a `Parameter` for the company id.
+
+        Returns None if the view doesn't use company_id (has set `company_id_field' to None`).
+        """
+        company_id_field = self.view.company_id_field
+        if company_id_field:
+            return Parameter(
+                name=company_id_field,
+                in_='query',
+                type='integer',
+                description='The ID of the company to manage',
+                required=True,
+            )
+
+        return None
+
+    def get_lookup_parameter(self):
+        """Helper function that creates a `Parameter` for the lookup parameter."""
+        if not getattr(self.view, 'request_serializer_class', None):
+            for field in ['lookup_query_field', 'lookup_arg_field', 'lookup_field']:
+                lookup_field = getattr(self.view, field, None)
+                if lookup_field:
+                    description = self.get_help_text(lookup_field)
+
+                    if not description:
+                        if lookup_field == 'id':
+                            description = 'The ID of the object'
+                        else:
+                            description = 'The lookup field'
+
+                    return Parameter(
+                        name=lookup_field,
+                        in_='query',
+                        type='string',
+                        required=True,
+                        description=description,
+                    )
+
+        return None
+
+    def add_parameters(self, parameters, new_parameters):
+        """
+        Helper function that merges two lists of parameters, avoiding duplicates.
+
+        Entries in `new_parameters` can be `Parameter` objects, or None (which is ignored).
+        """
+        for new in new_parameters:
+            if new:
+                for parameter in parameters:
+                    if parameter.name == new.name:
+                        break
+                else:
+                    parameters.append(new)
+
     def get_query_parameters(self):
+        """Get the parameters used when querying the endpoint."""
         parameters = super().get_query_parameters()
 
         if self.method in ['GET', 'DELETE']:
-            company_id_field = self.view.company_id_field
-            if company_id_field:
-                for parameter in parameters:
-                    if parameter.name == company_id_field:
-                        break
-                else:
-                    parameters.append(
-                        Parameter(
-                            name=company_id_field,
-                            in_='query',
-                            type='integer',
-                            description='The ID of the company to manage',
-                            required=True,
-                        )
-                    )
-
-            if not getattr(self.view, 'request_serializer_class', None):
-                for field in ['lookup_query_field', 'lookup_arg_field', 'lookup_field']:
-                    lookup_field = getattr(self.view, field, None)
-                    if lookup_field:
-                        for parameter in parameters:
-                            if parameter.name == lookup_field:
-                                break
-                        else:
-                            parameters.append(
-                                Parameter(
-                                    name=lookup_field,
-                                    in_='query',
-                                    type='string',
-                                    required=True,
-                                )
-                            )
-                        break
+            self.add_parameters(parameters, [
+                self.get_company_id_parameter(),
+                self.get_lookup_parameter(),
+            ])
 
         return parameters
 
     def get_query_serializer(self):
+        """Get the serializer used to deserialize query parameters."""
         serializer = super().get_query_serializer()
         serializer_class = getattr(self.view, 'request_serializer_class', None)
 
@@ -52,13 +118,14 @@ class LiquidatorAutoSchema(SwaggerAutoSchema):
 
         return serializer
 
-    def get_responses(self):
-        responses = super().get_responses()
+    def get_default_responses(self):
+        """Get the default responses."""
+        responses = super().get_default_responses()
 
-        if '401' not in responses:
-            responses['401'] = Response("Not authenticated")
-
-        if '403' not in responses:
-            responses['403'] = Response("You don't have access to do this operation on this company")
+        responses.update({
+            '400': 'Invalid arguments',
+            '401': 'Not authenticated',
+            '403': "You don't have access to do this operation on this company",
+        })
 
         return responses

--- a/base/mixins.py
+++ b/base/mixins.py
@@ -65,12 +65,13 @@ class ManyMixin:
 
 
 class ByDateRangeMixin:
+    request_serializer_class = DateRangeSerializer
     start_date_arg = 'start_date'
     end_date_arg = 'end_date'
     date_field = 'date'
 
     def get_date_range(self):
-        arg_serializer = DateRangeSerializer(data=self.get_data())
+        arg_serializer = self.request_serializer_class(data=self.get_data())
         arg_serializer.is_valid(raise_exception=True)
 
-        return (arg_serializer.validated_data['start_date'], arg_serializer.validated_data['end_date'])
+        return (arg_serializer.validated_data[self.start_date_arg], arg_serializer.validated_data[self.end_date_arg])

--- a/base/serializers.py
+++ b/base/serializers.py
@@ -48,13 +48,25 @@ class AppendIDMixin:
 
 
 class LiquidatorSerializer(AppendIDMixin, serializers.ModelSerializer):
+    """
+    A serializer that provides features that are useful for most
+    serializers in this project. Should be used as the default
+    serializer superclass.
+    """
     pass
 
 
 class DateSerializer(serializers.Serializer):
-    date = serializers.DateField()
+    """
+    A serializer that deserializes a date.
+
+    Useful as a request serializer, or to get a python
+    date from a date string.
+    """
+    date = serializers.DateField(help_text='The date')
 
 
 class DateRangeSerializer(serializers.Serializer):
-    start_date = serializers.DateField()
-    end_date = serializers.DateField()
+    """A serializer that deserializes a date range."""
+    start_date = serializers.DateField(help_text='The first date of the range (inclusive)')
+    end_date = serializers.DateField(help_text='The last day of the range (inclusive)')

--- a/company/models.py
+++ b/company/models.py
@@ -2,8 +2,8 @@ from django.db import models
 
 
 class Company(models.Model):
-    name = models.CharField(max_length=50, unique=True)
-    org_nr = models.CharField(max_length=20, unique=True)
+    name = models.CharField(max_length=50, unique=True, help_text='The name of the company')
+    org_nr = models.CharField(max_length=20, unique=True, help_text='The organization identifier')
 
     class Meta:
         verbose_name = 'company'

--- a/company/serializers.py
+++ b/company/serializers.py
@@ -6,7 +6,7 @@ from .models import Company
 
 
 class CompanySerializer(serializers.ModelSerializer):
-    users = serializers.SerializerMethodField(read_only=True)
+    users = serializers.SerializerMethodField(read_only=True, help_text='The users in the company')
 
     class Meta:
         model = Company

--- a/company/tests.py
+++ b/company/tests.py
@@ -104,41 +104,44 @@ class CompanyViewOwnerTestCase(CompanyTestMixin, JWTTestCase):
         user3 = self.create_user('user3@test.com', 'password3')
         user4 = self.create_user('user4@test.com', 'password4')
 
-        response = self.post(views.CompanyAddUserView, {'company_id': self.company.pk, 'user_id': user2.pk})
-        self.assertEquals(response.status_code, 200, msg=response.content)
+        response = self.post(views.CompanyUserView, {'company_id': self.company.pk, 'user_id': user2.pk})
+        self.assertEquals(response.status_code, 201, msg=response.content)
         self.assertTrue(user2.has_role(self.company, roles.USER), msg=response.content)
 
-        response = self.post(views.CompanyAddUserView,
+        response = self.post(views.CompanyUserView,
                              {'company_id': self.company.pk, 'user_id': user3.pk, 'role': roles.REPORTER})
-        self.assertEquals(response.status_code, 200, msg=response.content)
+        self.assertEquals(response.status_code, 201, msg=response.content)
         self.assertTrue(user3.has_role(self.company, roles.REPORTER), msg=response.content)
 
-        response = self.post(views.CompanyAddUserView,
-                             {'company_id': self.company.pk, 'user_id': user4.pk, 'role': None})
-        self.assertEquals(response.status_code, 200, msg=response.content)
+        response = self.post(views.CompanyUserView,
+                             {'company_id': self.company.pk, 'user_id': user4.pk})
+        self.assertEquals(response.status_code, 201, msg=response.content)
         self.assertTrue(user4.has_role(self.company, roles.USER), msg=response.content)
 
     def test_remove_user(self):
         user2 = self.create_user('user2@test.com', 'password2')
 
-        response = self.post(views.CompanyRemoveUserView, {'company_id': self.company.pk, 'user_id': user2.pk})
+        response = self.delete(views.CompanyUserView, {'company_id': self.company.pk})
+        self.assertEquals(response.status_code, 400, msg=response.content)
+
+        response = self.delete(views.CompanyUserView, {'company_id': self.company.pk, 'user_id': 100})
         self.assertEquals(response.status_code, 404, msg=response.content)
 
         self.set_role(self.company, user2, roles.REPORTER)
 
-        response = self.post(views.CompanyRemoveUserView, {'company_id': self.company.pk, 'user_id': user2.pk})
-        self.assertEquals(response.status_code, 200, msg=response.content)
+        response = self.delete(views.CompanyUserView, {'company_id': self.company.pk, 'user_id': user2.pk})
+        self.assertEquals(response.status_code, 204, msg=response.content)
         self.assertFalse(user2.has_role(self.company, roles.REPORTER), msg=response.content)
 
     def test_set_role(self):
         user2 = self.create_user('user2@test.com', 'password2')
 
         data = {'company_id': self.company.pk, 'user_id': user2.pk, 'role': roles.USER}
-        response = self.post(views.CompanySetRoleView, data)
+        response = self.put(views.CompanyUserView, data)
         self.assertEquals(response.status_code, 404, msg=response.content)
 
         self.set_role(self.company, user2, roles.REPORTER)
 
-        response = self.post(views.CompanySetRoleView, data)
+        response = self.put(views.CompanyUserView, data)
         self.assertEquals(response.status_code, 200, msg=response.content)
         self.assertTrue(user2.has_role(self.company, roles.USER), msg=response.content)

--- a/company/urls.py
+++ b/company/urls.py
@@ -1,11 +1,9 @@
 from django.urls import path
 
-from .views import CompanyView, CompanyAddUserView, CompanyRemoveUserView, CompanySetRoleView
+from .views import CompanyView, CompanyUserView
 
 
 urlpatterns = [
     path('', CompanyView.as_view(), name='company'),
-    path('addUser/', CompanyAddUserView.as_view(), name='company-add-user'),
-    path('removeUser/', CompanyRemoveUserView.as_view(), name='company-remove-user'),
-    path('setRole/', CompanySetRoleView.as_view(), name='company-set-role'),
+    path('user/', CompanyUserView.as_view(), name='company-add-user'),
 ]

--- a/company/views.py
+++ b/company/views.py
@@ -9,6 +9,7 @@ from .serializers import CompanySerializer
 
 
 class CompanyView(RetrieveCreateUpdateDestroyView):
+    """Manage a company."""
     queryset = Company.objects.all()
     serializer_class = CompanySerializer
     lookup_arg_field = 'company_id'
@@ -25,6 +26,7 @@ class CompanyView(RetrieveCreateUpdateDestroyView):
 
 
 class CompanyUserView(RetrieveCreateUpdateDestroyView):
+    """Manage users in a company."""
     # A little trick to add 'user_id' to the API spec
     lookup_field = 'user_id'
     serializer_class = UserCompanyThroughSerializer

--- a/company/views.py
+++ b/company/views.py
@@ -1,10 +1,9 @@
-from django.db.utils import IntegrityError
-
-from rest_framework.response import Response
+from rest_framework.generics import get_object_or_404
 
 from custom_auth import roles
 from custom_auth.models import UserCompanyThrough
-from base.views import CompanyAccessView, RetrieveCreateUpdateDestroyView
+from custom_auth.serializers import UserCompanyThroughSerializer
+from base.views import RetrieveCreateUpdateDestroyView
 from .models import Company
 from .serializers import CompanySerializer
 
@@ -25,54 +24,28 @@ class CompanyView(RetrieveCreateUpdateDestroyView):
         self.request.user.companies.add(company, through_defaults={'role': roles.OWNER})
 
 
-class CompanyUserMixin:
+class CompanyUserView(RetrieveCreateUpdateDestroyView):
+    # A little trick to add 'user_id' to the API spec
+    lookup_field = 'user_id'
+    serializer_class = UserCompanyThroughSerializer
+    queryset = UserCompanyThrough.objects.all()
     company_access = {
         'POST': roles.OWNER,
+        'PUT': roles.OWNER,
+        'DELETE': roles.OWNER,
     }
 
-    def post(self, request, *args, **kwargs):
-        company_id = self.get_company_id()
-        user_id = request.data['user_id']
+    def get_object(self):
+        data = self.get_data()
 
-        if 'role' in self.request.data and self.request.data['role']:
-            role = roles.get_role(request.data['role'])
+        # The serializer will check that the objects exists,
+        # returning a 400 when it doesn't exist. Therefore
+        # we handle the arguments manually, returning a 404 instead
+        if 'company_id' in data and 'user_id' in data:
+            company_id = data['company_id']
+            user_id = data['user_id']
+            return get_object_or_404(self.get_queryset(), company=company_id, user=user_id)
         else:
-            role = None
-
-        return self.handle_user(company_id, user_id, role)
-
-
-class CompanyAddUserView(CompanyUserMixin, CompanyAccessView):
-    def handle_user(self, company_id, user_id, role):
-        data = {'company_id': company_id, 'user_id': user_id}
-        if role:
-            data['role'] = role
-
-        try:
-            UserCompanyThrough.objects.create(**data)
-        except IntegrityError:
-            return Response({'detail': 'User not found'}, status='404')
-
-        return Response(status='200')
-
-
-class CompanyRemoveUserView(CompanyUserMixin, CompanyAccessView):
-    def handle_user(self, company_id, user_id, role):
-        try:
-            UserCompanyThrough.objects.get(user_id=user_id, company_id=company_id).delete()
-        except UserCompanyThrough.DoesNotExist:
-            return Response({'detail': 'The user is not member of this company'}, status='404')
-
-        return Response(status='200')
-
-
-class CompanySetRoleView(CompanyUserMixin, CompanyAccessView):
-    def handle_user(self, company_id, user_id, role):
-        queryset = UserCompanyThrough.objects.filter(user=user_id, company=company_id)
-
-        if queryset.exists():
-            queryset.update(role=role)
-        else:
-            return Response({'detail': 'The user is not member of this company'}, status='404')
-
-        return Response(status='200')
+            # We let the serializer handle creating the error
+            serializer = self.get_serializer_class()(data=data)
+            serializer.is_valid(raise_exception=True)

--- a/custom_auth/models.py
+++ b/custom_auth/models.py
@@ -34,11 +34,13 @@ class User(AbstractUser):
     email = models.EmailField(
         max_length=255,
         unique=True,
+        help_text='The users email',
     )
     companies = models.ManyToManyField(
         Company,
         through='UserCompanyThrough',
         related_name='users',
+        help_text='The companies the user has access to',
     )
 
     objects = UserManager()
@@ -81,15 +83,18 @@ class UserCompanyThrough(models.Model):
     user = models.ForeignKey(
         User,
         on_delete=models.CASCADE,
+        help_text='The user',
     )
     company = models.ForeignKey(
         Company,
         on_delete=models.CASCADE,
+        help_text='The company',
     )
     role = models.CharField(
         choices=roles.choices,
         max_length=2,
         default=roles.USER,
+        help_text='The users role in the company',
     )
 
     def __str__(self):

--- a/custom_auth/serializers.py
+++ b/custom_auth/serializers.py
@@ -31,11 +31,11 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class LoginSerializer(serializers.Serializer):
-    email = serializers.EmailField()
-    password = serializers.CharField()
+    email = serializers.EmailField(help_text='The email')
+    password = serializers.CharField(help_text='The password')
 
 
 class UserTokenSerializer(serializers.Serializer):
-    user = UserSerializer()
-    refresh = serializers.CharField()
-    access = serializers.CharField()
+    user = UserSerializer(help_text='The current user')
+    refresh = serializers.CharField(help_text='The refresh token')
+    access = serializers.CharField(help_text='The access token')

--- a/custom_auth/serializers.py
+++ b/custom_auth/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from drf_yasg.utils import swagger_serializer_method
 
 from base.serializers import LiquidatorSerializer
 from .models import User, UserCompanyThrough
@@ -18,6 +19,7 @@ class UserSerializer(serializers.ModelSerializer):
         fields = ('id', 'email', 'password', 'first_name', 'last_name', 'companies')
         extra_kwargs = {'password': {'write_only': True, 'required': False}}
 
+    @swagger_serializer_method(serializers.ListField(child=UserCompanyThroughSerializer()))
     def get_companies(self, obj):
         return UserCompanyThroughSerializer(UserCompanyThrough.objects.filter(user=obj), many=True).data
 
@@ -26,3 +28,14 @@ class UserSerializer(serializers.ModelSerializer):
         user.set_password(validated_data['password'])
         user.save()
         return user
+
+
+class LoginSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    password = serializers.CharField()
+
+
+class UserTokenSerializer(serializers.Serializer):
+    user = UserSerializer()
+    refresh = serializers.CharField()
+    access = serializers.CharField()

--- a/custom_auth/tests.py
+++ b/custom_auth/tests.py
@@ -21,7 +21,7 @@ class AuthenticationTestCase(JWTTestCase):
 
     def test_incorrect_login(self):
         response = self.post(views.Login, {'email': self.email, 'password': 'wrong'})
-        self.assertEquals(response.status_code, 400, msg=response.content)
+        self.assertEquals(response.status_code, 404, msg=response.content)
 
     def test_correct_JWT_refresh(self):
         response = self.post(views.Login, {'email': self.email, 'password': self.password})

--- a/custom_auth/urls.py
+++ b/custom_auth/urls.py
@@ -1,12 +1,23 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenRefreshView
+from drf_yasg.inspectors import SwaggerAutoSchema
+from drf_yasg.utils import swagger_auto_schema
 
 from .views import Login, UserView, UserByEmailView
 
 
+# As this view is defined outside out code,
+# we have to do this to override API definitions
+token_refresh_view = swagger_auto_schema(
+    method='post',
+    auto_schema=SwaggerAutoSchema,
+    responses={'401': 'Invalid token'}
+)(TokenRefreshView.as_view())
+
+
 urlpatterns = [
     path('login/', Login.as_view(), name='login'),
-    path('refresh/', TokenRefreshView.as_view(), name='token-refresh'),
+    path('refresh/', token_refresh_view, name='token-refresh'),
     path('', UserView.as_view(), name='user'),
     path('byEmail/', UserByEmailView.as_view(), name='user-by-email'),
 ]

--- a/custom_auth/utils.py
+++ b/custom_auth/utils.py
@@ -1,0 +1,9 @@
+from rest_framework_simplejwt.tokens import RefreshToken
+
+
+class UserToken:
+    def __init__(self, user):
+        self.user = user
+        self.token = RefreshToken.for_user(user)
+        self.refresh = str(self.token)
+        self.access = str(self.token.access_token)

--- a/custom_auth/views.py
+++ b/custom_auth/views.py
@@ -12,12 +12,14 @@ from .serializers import UserSerializer, LoginSerializer, UserTokenSerializer
 
 
 class Login(APIView):
+    """Log an user into the system."""
     missing_msg = 'Please provide email/password'
     invalid_msg = 'Invalid email/password'
 
     @swagger_auto_schema(
         auto_schema=SwaggerAutoSchema,
         request_body=LoginSerializer,
+        security=[],
         responses={
             '200': UserTokenSerializer(),
             '400': missing_msg,
@@ -57,12 +59,9 @@ class UserMixin:
            and data[self.lookup_field] != getattr(request.user, self.lookup_field):
             super().check_company_role(request, *args, **kwargs)
 
-    def post(self, request, *args, **kwargs):
-        request.data['companies'] = []
-        return super().post(request, *args, **kwargs)
-
 
 class UserView(UserMixin, RetrieveCreateUpdateDestroyView):
+    """Manage the current user."""
     permissions = {
         'POST': None,
     }
@@ -86,6 +85,16 @@ class UserView(UserMixin, RetrieveCreateUpdateDestroyView):
 
         return response
 
+    @swagger_auto_schema(security=[], responses={'401': None, '403': None})
+    def post(self, request, *args, **kwargs):
+        """
+        Create a new user. This doesn't require being logged in,
+        and the new user is automatically logged in after creation.
+        """
+        request.data['companies'] = []
+        return super().post(request, *args, **kwargs)
+
 
 class UserByEmailView(UserMixin, RetrieveView):
+    """Get a user by their email."""
     lookup_field = 'email'

--- a/liquidator/settings.py
+++ b/liquidator/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'drf_yasg',
     'corsheaders',
     'base',
     'company',
@@ -147,6 +148,10 @@ SIMPLE_JWT = {
     'SLIDING_TOKEN_REFRESH_EXP_CLAIM': 'refresh_exp',
     'SLIDING_TOKEN_LIFETIME': timedelta(days=1),
     'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=5),
+}
+
+SWAGGER_SETTINGS = {
+    'DEFAULT_AUTO_SCHEMA_CLASS': 'base.api.LiquidatorAutoSchema',
 }
 
 

--- a/liquidator/urls.py
+++ b/liquidator/urls.py
@@ -15,6 +15,9 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
 import custom_auth.urls
 import company.urls
@@ -22,6 +25,17 @@ import transaction.urls.transaction
 import transaction.urls.recurring
 import balance.urls
 import balance.month_urls
+
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title='Liquidator API',
+        default_version='1.0.0',
+        license=openapi.License(name='MIT License'),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
 
 
 urlpatterns = [
@@ -32,4 +46,5 @@ urlpatterns = [
     path('recurring/', include(transaction.urls.recurring)),
     path('balance/', include(balance.urls)),
     path('month/', include(balance.month_urls)),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ djangorestframework_simplejwt
 flake8
 django-cors-headers
 python-dateutil
+drf-yasg
+packaging

--- a/transaction/models.py
+++ b/transaction/models.py
@@ -12,21 +12,23 @@ class TransactionStaticData(models.Model):
         (EXPENSE, 'expense'),
     )
 
-    money = models.IntegerField()
-    type = models.CharField(max_length=2, choices=TRANSACTION_CHOICES)
-    description = models.TextField()
-    notes = models.TextField(blank=True)
+    money = models.IntegerField(help_text='The amount of money transferred in the transaction')
+    type = models.CharField(max_length=2, choices=TRANSACTION_CHOICES,
+                            help_text='The type of transaction (income or expense)')
+    description = models.TextField(help_text='A short description of what the transaction is for')
+    notes = models.TextField(blank=True, help_text='A longer description and details about the transaction')
 
     class Meta:
         abstract = True
 
 
 class Transaction(TransactionStaticData):
-    date = models.DateField()
+    date = models.DateField(help_text='The date of the transaction')
     company = models.ForeignKey(
         Company,
         related_name='transactions',
         on_delete=models.CASCADE,
+        help_text='The company'
     )
     recurring_transaction = models.ForeignKey(
         'RecurringTransaction',
@@ -34,6 +36,7 @@ class Transaction(TransactionStaticData):
         on_delete=models.DO_NOTHING,
         null=True,
         blank=True,
+        help_text='The associated recurring transaction, if applicable',
     )
 
     def __str__(self):
@@ -44,19 +47,23 @@ class Transaction(TransactionStaticData):
 
 
 class RecurringTransaction(models.Model):
-    day_delta = models.PositiveIntegerField()
-    month_delta = models.PositiveIntegerField()
-    start_date = models.DateField()
-    end_date = models.DateField()
+    day_delta = models.PositiveIntegerField(help_text='The number of days between each occurence')
+    month_delta = models.PositiveIntegerField(help_text='The number of months between each occurence')
+    start_date = models.DateField(help_text='The day of the first occurence')
+    end_date = models.DateField(
+        help_text="The last day there can be an occurence. Doesn't have to be the date of an occurence"
+    )
 
     company = models.ForeignKey(
         Company,
         related_name='recurring_transactions',
         on_delete=models.CASCADE,
+        help_text='The company that has this recurring transaction',
     )
     template = models.OneToOneField(
         'TransactionTemplate',
         on_delete=models.CASCADE,
+        help_text='The template for the transaction occurences'
     )
 
     def get_occurences(self, start_date, end_date, include_created=True):

--- a/transaction/serializers.py
+++ b/transaction/serializers.py
@@ -42,5 +42,6 @@ class RecurringTransactionSerializer(LiquidatorSerializer):
 
 
 class RecurringTransactionOccurenceSerializer(serializers.Serializer):
-    object = RecurringTransactionSerializer()
-    dates = serializers.ListField(child=serializers.DateField())
+    object = RecurringTransactionSerializer(help_text='The recurring transaction object')
+    dates = serializers.ListField(child=serializers.DateField(),
+                                  help_text='The dates the recurring transaction occures on')

--- a/transaction/views.py
+++ b/transaction/views.py
@@ -14,29 +14,35 @@ class TransactionMixin(CompanyFilterMixin):
 
 
 class TransactionView(TransactionMixin, RetrieveCreateUpdateDestroyView):
+    """Manage a transaction for a company."""
     pass
 
 
 class TransactionAllView(TransactionMixin, ListView):
+    """Get all transactions for a company."""
     pass
 
 
 class TransactionByDateView(TransactionMixin, ListView):
+    """Get all transactions for a company on a given date."""
     def get_queryset(self):
         data = self.get_data()
         return super().get_queryset().filter(date=data['date'])
 
 
 class TransactionByDateRangeView(TransactionMixin, ByDateRangeView):
+    """Get all transactions for a company in a given date range."""
     pass
 
 
 class TransactionIncomeAllView(TransactionMixin, ListView):
+    """Get all income transactions for a company."""
     def get_queryset(self):
         return super().get_queryset().filter(type=TransactionStaticData.INCOME)
 
 
 class TransactionExpenseAllView(TransactionMixin, ListView):
+    """Get all expense transactions for a company."""
     def get_queryset(self):
         return super().get_queryset().filter(type=TransactionStaticData.EXPENSE)
 
@@ -48,16 +54,23 @@ class RecurringTransactionMixin(CompanyFilterMixin):
 
 
 class RecurringView(RecurringTransactionMixin, RetrieveCreateUpdateDestroyView):
+    """Manage a recurring transaction for a company."""
     def perform_destroy(self, instance):
         instance.template.delete()
         super().perform_destroy(instance)
 
 
 class RecurringAllView(RecurringTransactionMixin, ListView):
+    """Get all recurring transactions for a company."""
     pass
 
 
 class RecurringActive(RecurringTransactionMixin, ListView):
+    """
+    Get all recurring transactions for a company that currenctly active.
+    A recurring transaction is active if the current date is between its
+    `start_date` and `end_date`.
+    """
     def get_queryset(self):
         return super().get_queryset().filter(start_date__lte=date.today(), end_date__gte=date.today())
 


### PR DESCRIPTION
Uses the `drf-yasg` package to generate a Swagger API from the python code. The API is available at `/swagger/`.

This does not solve all our API problems. The code is somewhat advanced, in a way that the generator cannot natively understand. I've tried to override the default generator to mitigate this, but we still have to specify some things manually.

There are also some small bugs, like the `RecurringTransaction` object being named `Object`. I have no idea how to fix these, but they aren't critical.

Fixes #55 