### PR TITLE
Standardize error messages

### DIFF
--- a/base/api.py
+++ b/base/api.py
@@ -1,6 +1,8 @@
 from drf_yasg.inspectors import SwaggerAutoSchema
 from drf_yasg.openapi import Parameter
 
+from .serializers import ErrorSerializer
+
 
 class LiquidatorAutoSchema(SwaggerAutoSchema):
     """
@@ -126,6 +128,7 @@ class LiquidatorAutoSchema(SwaggerAutoSchema):
             '400': 'Invalid arguments',
             '401': 'Not authenticated',
             '403': "You don't have access to do this operation on this company",
+            'error': ErrorSerializer,
         })
 
         return responses

--- a/base/exception_handlers.py
+++ b/base/exception_handlers.py
@@ -1,0 +1,126 @@
+import logging
+from django.http.response import Http404
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+from rest_framework.exceptions import ValidationError, ErrorDetail
+from rest_framework_simplejwt.exceptions import InvalidToken
+
+from .utils import ErrorType, ErrorEntry, Error
+from .serializers import ErrorSerializer
+
+logger = logging.getLogger(__name__)
+
+
+def server_error():
+    """Return a standard 500 response"""
+    serializer = ErrorSerializer(
+        Error(
+            errors=[{'code': 'server_error', 'detail': 'Internal server error.'}],
+        )
+    )
+
+    return Response(data=serializer.data, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+def custom_exception_handler(exc, context):
+    """
+    A custom exception handler that makes sure errors are returned with a fixed format.
+
+    Django, django-rest-framework, and the jwt framework all throw exceptions in slightly
+    different ways. This has to be caught and each type of exception has to be converted
+    to the common error format.
+
+    This function is called whenever there is an uncaught exception in the code. It doesn't
+    handle responses with error codes.
+
+    As this is the last line of defense, it will check every possibility, and log all errors,
+    so that they can be easily found and fixed.
+    """
+    # Let django-rest-framework do its handling. This might return None
+    # The response variable will be ignored at the end, so don't set the
+    # status code or data directly on that.
+    response = exception_handler(exc, context)
+
+    # Define variables that can be modified during handling, and will be
+    # converted to a Response at the end. We default to status code 400.
+    status_code = response.status_code if response else '400'
+    error = Error()
+
+    try:
+        if isinstance(exc, ValidationError):
+            # It's a rest framework ValidationError
+            error.error_type = ErrorType.FORM_ERROR
+
+            if isinstance(exc.detail, dict):
+                error.errors = [ErrorEntry.factory(obj)
+                                for obj in exc.detail.pop('non_field_errors', [])]
+
+                error.field_errors = {key: [ErrorEntry.factory(obj)
+                                            for obj in exc.detail[key]]
+                                      for key in exc.detail}
+            elif isinstance(exc.detail, list):
+                error.errors = [ErrorEntry.factory(obj) for obj in exc.detail]
+            else:
+                logger.error('Unable to parse detail attribute (%s) on exception %s', exc.detail, repr(exc))
+                return server_error()
+        elif isinstance(exc, InvalidToken):
+            # It's an error from simplejwt
+            error.error_type = ErrorType.JWT_ERROR
+
+            if isinstance(exc.detail, dict):
+                error.errors = [ErrorEntry.factory(exc.detail['detail'])]
+            else:
+                logger.error('Unable to parse detail attribute (%s) on exception %s', exc.detail, repr(exc))
+                return server_error()
+        elif isinstance(exc, DjangoValidationError):
+            # It's a django ValidationError
+            error.error_type = ErrorType.FORM_ERROR
+            status_code = status.HTTP_400_BAD_REQUEST
+
+            # The ValidationError might, or might not, have the code attribute set.
+            # It might also be None
+            error_code = exc.code if hasattr(exc, 'code') and exc.code else 'invalid'
+
+            try:
+                # Validation errors are usually dicts with the field name as the key
+                message_dict = exc.message_dict
+                error.errors = [ErrorEntry(code=error_code, detail=message)
+                                for message in message_dict.pop('non_field_errors', [])]
+                error.field_errors = {key: [ErrorEntry(code=error_code, detail=message)
+                                            for message in messages]
+                                      for key, messages in message_dict.items()}
+            except AttributeError:
+                # If an argument with an invalid format is used in a queryset `filter()`
+                # we only get a list of errors, not a dict.
+                error.errors = [ErrorEntry(code=error_code, detail=message)
+                                for message in exc]
+        elif isinstance(exc, Http404):
+            # It's a Http404 exception (probably from `get_or_404`)
+            status_code = status.HTTP_404_NOT_FOUND
+            error.errors = [ErrorEntry(detail=str(exc), code='not_found')]
+        elif hasattr(exc, 'detail'):
+            if isinstance(exc.detail, ErrorDetail):
+                error.errors = [ErrorEntry.factory(exc.detail)]
+            elif isinstance(exc.detail, list) and all(isinstance(detail, ErrorDetail)
+                                                      for detail in exc.detail):
+                error.errors = [ErrorEntry.factory(item)
+                                for item in exc.detail]
+            else:
+                logger.error('Unable to parse detail attribute (%s) on exception %s', exc.detail, repr(exc))
+                return server_error()
+        else:
+            # It's an unknown exception, so we don't know how to get the data from it.
+            # Return a 500, log the data, and hope someone sees it.
+            logger.error('Unable to handle exception: %s', repr(exc))
+            return server_error()
+    except Exception as e:
+        # There was an exception while processing the exception.
+        # Return a 500, log the data, and hope someone sees it.
+        logger.error('Exception (%s) occurred during handling of exception: %s', repr(e), repr(exc))
+        return server_error()
+
+    # Convert the Error object into a JSON response, and return it
+    serializer = ErrorSerializer(error)
+    return Response(data=serializer.data, status=status_code)

--- a/base/tests.py
+++ b/base/tests.py
@@ -1,6 +1,12 @@
+import logging
 from django.test import TestCase
 from django.utils.http import urlencode
+from django.core import exceptions as django_exceptions
+from django.http import Http404
+from rest_framework import exceptions as rest_exceptions
 from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+from rest_framework_simplejwt import exceptions as jwt_exceptions
 from rest_framework_simplejwt.views import TokenRefreshView
 from rest_framework_simplejwt.tokens import RefreshToken
 
@@ -113,3 +119,179 @@ class JWTTestCase(UserTestMixin, TestCase):
 
     def delete(self, *args, **kwargs):
         return self.perform_request('DELETE', *args, **kwargs)
+
+
+class ExceptionHandlerTestCase(JWTTestCase):
+    class DetailException(Exception):
+        def __init__(self, detail):
+            self.detail = detail
+
+    def create_view(self, exc):
+        """
+        Create a temporary view that only casts an exception.
+
+        The exc parameter can be an instance of an exception,
+        or a function that raises an exception.
+        """
+        class ExceptionView(APIView):
+            def get(self, *args, **kwargs):
+                if isinstance(exc, Exception):
+                    raise exc
+                else:
+                    exc()
+
+        return ExceptionView
+
+    def force_error(self, exc):
+        """Shorthand for `create_view()` and `get()`"""
+        return self.get(self.create_view(exc))
+
+    def validation_error_helper(self, exc_class, code=None):
+        msg = 'Error'
+        response = self.force_error(
+            exc_class(msg, code=code)
+        )
+        expected = {
+            'error_type': 'form_error',
+            'errors': [{'code': 'invalid', 'detail': msg}],
+            'field_errors': {},
+        }
+        self.assertEqual(response.status_code, 400, msg=response.data)
+        self.assertDictEqual(response.data, expected, msg=response.data)
+
+        response = self.force_error(
+            exc_class([msg, msg], code=code)
+        )
+        expected = {
+            'error_type': 'form_error',
+            'errors': [
+                {'code': 'invalid', 'detail': msg},
+                {'code': 'invalid', 'detail': msg},
+            ],
+            'field_errors': {},
+        }
+        self.assertEqual(response.status_code, 400, msg=response.data)
+        self.assertDictEqual(response.data, expected, msg=response.data)
+
+        field = 'date'
+        field_msg = 'field error'
+        non_field_msg = 'non field error'
+        response = self.force_error(
+            exc_class({
+                field: [field_msg],
+                'non_field_errors': [non_field_msg],
+            }, code=code)
+        )
+        expected = {
+            'error_type': 'form_error',
+            'errors': [
+                {'code': 'invalid', 'detail': non_field_msg},
+            ],
+            'field_errors': {
+                field: [{'code': 'invalid', 'detail': field_msg}]
+            },
+        }
+        self.assertEqual(response.status_code, 400, msg=response.data)
+        self.assertDictEqual(response.data, expected, msg=response.data)
+
+    def test_rest_validation_error(self):
+        self.validation_error_helper(rest_exceptions.ValidationError)
+
+    def test_django_validation_error(self):
+        self.validation_error_helper(django_exceptions.ValidationError)
+
+    def test_jwt_errors(self):
+        msg = 'Token error'
+        response = self.force_error(
+            jwt_exceptions.InvalidToken(msg)
+        )
+        expected = {
+            'error_type': 'jwt_error',
+            'errors': [
+                {'code': 'token_not_valid', 'detail': msg},
+            ],
+            'field_errors': {},
+        }
+        self.assertEqual(response.status_code, 401, msg=response.data)
+        self.assertDictEqual(response.data, expected, msg=response.data)
+
+    def test_http_404_error(self):
+        msg = 'Object not found'
+        response = self.force_error(
+            Http404(msg)
+        )
+        expected = {
+            'error_type': 'error',
+            'errors': [
+                {'code': 'not_found', 'detail': msg},
+            ],
+            'field_errors': {},
+        }
+        self.assertEqual(response.status_code, 404, msg=response.data)
+        self.assertDictEqual(response.data, expected, msg=response.data)
+
+    def test_misc_exceptions(self):
+        msg = 'Object not found'
+        code = 'test'
+
+        response = self.force_error(
+            self.DetailException(rest_exceptions.ErrorDetail(msg, code))
+        )
+        expected = {
+            'error_type': 'error',
+            'errors': [
+                {'code': code, 'detail': msg},
+            ],
+            'field_errors': {},
+        }
+        self.assertEqual(response.status_code, 400, msg=response.data)
+        self.assertDictEqual(response.data, expected, msg=response.data)
+
+        response = self.force_error(
+            self.DetailException([
+                rest_exceptions.ErrorDetail(msg, code),
+                rest_exceptions.ErrorDetail(msg, code),
+            ])
+        )
+        expected = {
+            'error_type': 'error',
+            'errors': [
+                {'code': code, 'detail': msg},
+                {'code': code, 'detail': msg},
+            ],
+            'field_errors': {},
+        }
+        self.assertEqual(response.status_code, 400, msg=response.data)
+        self.assertDictEqual(response.data, expected, msg=response.data)
+
+        # Disable logging, so we don't spam the test log
+        logging.disable(logging.CRITICAL)
+        response = self.force_error(
+            self.DetailException([
+                rest_exceptions.ErrorDetail(msg, code),
+                "should be an ErrorDetail",
+            ])
+        )
+        logging.disable(logging.NOTSET)
+
+        self.assertEqual(response.status_code, 500, msg=response.data)
+
+    def test_invalid_exceptions(self):
+        msg = 'Token error'
+
+        # Disable logging, so we don't spam the test log
+        logging.disable(logging.CRITICAL)
+        response = self.force_error(
+            Exception(msg)
+        )
+        logging.disable(logging.NOTSET)
+
+        expected = {
+            'error_type': 'error',
+            'errors': [
+                {'code': 'server_error', 'detail': 'Internal server error.'},
+            ],
+            'field_errors': {},
+        }
+        self.assertEqual(response.status_code, 500, msg=response.data)
+        self.assertDictEqual(response.data, expected, msg=response.data)

--- a/base/utils.py
+++ b/base/utils.py
@@ -1,0 +1,32 @@
+from enum import Enum
+from typing import List
+from dataclasses import dataclass, field
+from rest_framework.exceptions import ErrorDetail
+
+
+class ErrorType(Enum):
+    ERROR = 'error'
+    FORM_ERROR = 'form_error'
+    JWT_ERROR = 'jwt_error'
+
+
+@dataclass
+class ErrorEntry:
+    code: str
+    detail: str
+
+    @classmethod
+    def factory(self, obj):
+        if isinstance(obj, ErrorDetail):
+            return ErrorEntry(code=obj.code, detail=str(obj))
+        elif isinstance(obj, dict):
+            return ErrorEntry(code=obj['code'], detail=obj['detail'])
+        else:
+            raise TypeError('obj should be a ErrorDetail or a dict')
+
+
+@dataclass
+class Error:
+    error_type: ErrorType = ErrorType.ERROR
+    errors: List[ErrorEntry] = field(default_factory=list)
+    field_errors: dict = field(default_factory=dict)

--- a/custom_auth/views.py
+++ b/custom_auth/views.py
@@ -85,10 +85,6 @@ class UserView(UserMixin, RetrieveCreateUpdateDestroyView):
 
         return response
 
-    def perform_destroy(self, instance):
-        print(f'Deleting user {instance}')
-        super().perform_destroy(instance)
-
     @swagger_auto_schema(security=[], responses={'201': UserTokenSerializer, '401': None, '403': None})
     def post(self, request, *args, **kwargs):
         """

--- a/liquidator/settings.py
+++ b/liquidator/settings.py
@@ -124,6 +124,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 50,
+    'EXCEPTION_HANDLER': 'base.exception_handlers.custom_exception_handler',
 }
 
 SIMPLE_JWT = {

--- a/transaction/tests.py
+++ b/transaction/tests.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime, timedelta
-from django.core.exceptions import ValidationError
 
 from base.tests import JWTTestCase
 from custom_auth import roles
@@ -199,8 +198,8 @@ class TransactionByDateTestCase(TransactionTestMixin, JWTTestCase):
     def test_invalid_date_format(self):
         test_date = '2019,88,102'
 
-        with self.assertRaises(ValidationError):
-            self.get(views.TransactionByDateView, {'date': test_date})
+        response = self.get(views.TransactionByDateView, {'date': test_date})
+        self.assertEquals(response.status_code, 400, msg=response.content)
 
 
 class TransactionByDateRangeTestCase(TransactionTestMixin, JWTTestCase):

--- a/transaction/views.py
+++ b/transaction/views.py
@@ -4,8 +4,6 @@ from base.mixins import CompanyFilterMixin
 from .serializers import TransactionSerializer, RecurringTransactionSerializer
 from .models import Transaction, TransactionStaticData, RecurringTransaction
 
-# TODO: Implement logic when mixins are pushed
-
 
 class TransactionMixin(CompanyFilterMixin):
     lookup_field = 'id'


### PR DESCRIPTION
Return all errors in a common format. This format can be seen in the swagger API, under the 'error' response for all endpoints.

If the backend doesn't know how to parse an error into this format, a 500 is returned, and the error is logged.