### PR TITLE
Dockerfile: run as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.7-slim
 
 ENV PYTHONUNBUFFERED 1
 
+RUN useradd django -u 1000 -U -s /bin/false
+
 WORKDIR /code
 
 COPY requirements.txt /code/
@@ -9,3 +11,5 @@ COPY requirements.txt /code/
 RUN pip install -r /code/requirements.txt
 
 COPY . /code/
+
+USER django


### PR DESCRIPTION
The impetus for this change is my annoyance with root owned files created in my workspace (and some appendant issues with stale pycache files). In a real production scenario it seems prudent to avoid running as root in the container anyhow, though I expect this is not a high-priority concern just yet.

The user is given uid 1000 to match the (presumed) uid of the host user, to avoid mismatches in the common scenario of running with /code/ bind mounted from host.